### PR TITLE
OT 90 Documentación con swagger

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,8 @@ const path = require('path');
 const cookieParser = require('cookie-parser');
 const logger = require('morgan');
 const cors = require('cors');
+const swaggerUI = require('swagger-ui-express');
+const docs = require('./docs');
 require('dotenv').config();
 
 const indexRouter = require('./routes/index');
@@ -31,6 +33,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
+app.use('/docs', swaggerUI.serve, swaggerUI.setup(docs));
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
 app.use('/organization', organizationRouter);

--- a/docs/basicInfo.js
+++ b/docs/basicInfo.js
@@ -1,0 +1,8 @@
+module.exports = {
+  openapi: '3.0.3', // Versión de specificación openapi
+  info: {
+    title: 'Prueba Swager', // Titulo de la api.
+    description: 'API ONG - Somos Más', //  descripción.
+    version: '1.0.0' // version de la api
+  }
+};

--- a/docs/components/address.schema.js
+++ b/docs/components/address.schema.js
@@ -1,0 +1,23 @@
+module.exports = {
+  Address: {
+    type: 'object',
+    properties: {
+      street: {
+        type: 'string',
+        example: '437 Americas'
+      },
+      city: {
+        type: 'string',
+        example: 'Bogotá'
+      },
+      state: {
+        type: 'string',
+        example: 'Cundinamarca'
+      },
+      zip: {
+        type: 'string',
+        example: '94301'
+      }
+    }
+  }
+};

--- a/docs/components/apiresponse.schema.js
+++ b/docs/components/apiresponse.schema.js
@@ -1,0 +1,17 @@
+module.exports = {
+  ApiResponse: {
+    type: 'object',
+    properties: {
+      code: {
+        type: 'integer',
+        format: 'int32'
+      },
+      type: {
+        type: 'string'
+      },
+      message: {
+        type: 'string'
+      }
+    }
+  }
+};

--- a/docs/components/error.schema.js
+++ b/docs/components/error.schema.js
@@ -1,0 +1,22 @@
+module.exports = {
+  NotFound: {
+    description: 'Recurso no encontrado',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/ApiResponse'
+        }
+      }
+    }
+  },
+  Unauthorized: {
+    description: 'Unauthorized',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/ApiResponse'
+        }
+      }
+    }
+  }
+};

--- a/docs/components/index.js
+++ b/docs/components/index.js
@@ -1,0 +1,25 @@
+const apiresponse = require('./apiresponse.schema');
+const error = require('./error.schema');
+const user = require('./user.schema');
+const address = require('./address.schema');
+
+module.exports = {
+  components: {
+    schemas: {
+      ...user,
+      ...address,
+      ...apiresponse
+    },
+    responses: {
+      ...error
+    },
+    securitySchemes: {
+      //scemas de seguridad bearer token para proteger las rutas
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT'
+      }
+    }
+  }
+};

--- a/docs/components/user.schema.js
+++ b/docs/components/user.schema.js
@@ -1,0 +1,30 @@
+module.exports = {
+  User: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'integer',
+        format: 'int64',
+        example: 10
+      },
+      username: {
+        type: 'string',
+        example: 'theUser'
+      },
+      email: {
+        type: 'string',
+        example: 'user@mail.com'
+      },
+      password: {
+        type: 'string',
+        example: '123456'
+      },
+      address: {
+        type: 'array',
+        items: {
+          $ref: '#components/schemas/Address'
+        }
+      }
+    }
+  }
+};

--- a/docs/index.js
+++ b/docs/index.js
@@ -1,0 +1,13 @@
+const basicInfo = require('./basicInfo');
+const server = require('./server');
+const tags = require('./tags');
+const components = require('./components');
+const paths = require('./paths');
+
+module.exports = {
+  ...basicInfo,
+  ...server,
+  ...tags,
+  ...components,
+  ...paths
+};

--- a/docs/paths/index.js
+++ b/docs/paths/index.js
@@ -1,0 +1,6 @@
+const user = require('./user');
+module.exports = {
+  paths: {
+    ...user
+  }
+};

--- a/docs/paths/user/index.js
+++ b/docs/paths/user/index.js
@@ -1,0 +1,10 @@
+const userPath = require('./user.path');
+
+module.exports = {
+  '/user': {
+    ...userPath.base
+  },
+  '/user/{userId}': {
+    ...userPath.byId
+  }
+};

--- a/docs/paths/user/user.path.js
+++ b/docs/paths/user/user.path.js
@@ -1,0 +1,183 @@
+// Ejemplo de un path con valores en query
+const base = {
+  get: {
+    tags: ['User'],
+    description: 'Listar usuarios',
+    operationId: 'getUsers', //debe ser unico en toda la documentación
+    parameters: [
+      {
+        in: 'query',
+        name: 'limit'
+      },
+      {
+        in: 'query',
+        name: 'offset'
+      }
+    ],
+    responses: {
+      200: {
+        description: 'OK',
+        content: {
+          'aplication/json': {
+            schema: {
+              $ref: '#/components/schemas/ApiResponse'
+            }
+          }
+        }
+      },
+      400: {
+        $ref: '#components/responses/NotFound'
+      },
+      401: {
+        $ref: '#components/responses/Unauthorized'
+      }
+    }
+  },
+  // Request de tipo post y protección con bearear
+  post: {
+    tags: ['User'],
+    description: 'crear Usuario',
+    operationId: 'postUser',
+    parameters: [],
+    security: [{ bearerAuth: [] }],
+    requestBody: {
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/User'
+          }
+        }
+      }
+    },
+    responses: {
+      200: {
+        description: 'OK',
+        content: {
+          'aplication/json': {
+            schema: {
+              $ref: '#/components/schemas/ApiResponse'
+            }
+          }
+        }
+      },
+      400: {
+        $ref: '#components/responses/NotFound'
+      },
+      401: {
+        $ref: '#components/responses/Unauthorized'
+      }
+    }
+  }
+};
+
+const byId = {
+  get: {
+    tags: ['User'],
+    description: 'Detalles de usuario',
+    operationId: 'getUser',
+    parameters: [
+      {
+        in: 'path',
+        name: 'userId',
+        schema: {
+          type: 'integer'
+        },
+        required: true,
+        description: 'Id del usuario'
+      }
+    ],
+    responses: {
+      200: {
+        description: 'OK',
+        content: {
+          'aplication/json': {
+            schema: {
+              $ref: '#/components/schemas/ApiResponse'
+            }
+          }
+        }
+      },
+      400: {
+        $ref: '#components/responses/NotFound'
+      },
+      401: {
+        $ref: '#components/responses/Unauthorized'
+      }
+    }
+  },
+
+  put: {
+    tags: ['User'],
+    description: 'Editar usuario',
+    operationId: 'putUSer',
+    parameters: [
+      {
+        in: 'path',
+        name: 'userId',
+        schema: {
+          type: 'integer'
+        },
+        required: true,
+        description: 'Id del usuario'
+      }
+    ],
+    responses: {
+      200: {
+        description: 'OK',
+        content: {
+          'aplication/json': {
+            schema: {
+              $ref: '#/components/schemas/ApiResponse'
+            }
+          }
+        }
+      },
+      400: {
+        $ref: '#components/responses/NotFound'
+      },
+      401: {
+        $ref: '#components/responses/Unauthorized'
+      }
+    }
+  },
+
+  delete: {
+    tags: ['User'],
+    description: 'Eliminar usuario',
+    operationId: 'delUSer',
+    parameters: [
+      {
+        in: 'path',
+        name: 'userId',
+        schema: {
+          type: 'integer'
+        },
+        required: true,
+        description: 'Id del usuario'
+      }
+    ],
+    responses: {
+      200: {
+        description: 'OK',
+        content: {
+          'aplication/json': {
+            schema: {
+              $ref: '#/components/schemas/ApiResponse'
+            }
+          }
+        }
+      },
+      400: {
+        $ref: '#components/responses/NotFound'
+      },
+      401: {
+        $ref: '#components/responses/Unauthorized'
+      }
+    }
+  }
+};
+
+module.exports = {
+  base,
+  byId
+};

--- a/docs/server.js
+++ b/docs/server.js
@@ -1,0 +1,8 @@
+module.exports = {
+  servers: [
+    {
+      url: 'http://localhost:3000', // url
+      description: 'Local server' // name
+    }
+  ]
+};

--- a/docs/tags.js
+++ b/docs/tags.js
@@ -1,0 +1,7 @@
+module.exports = {
+  tags: [
+    {
+      name: 'User' // name of a tag
+    }
+  ]
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "jsonwebtoken": "^8.5.1",
         "morgan": "~1.9.1",
         "mysql2": "^2.2.3",
-        "sequelize": "^6.3.5"
+        "sequelize": "^6.3.5",
+        "swagger-ui-express": "^4.5.0"
       },
       "devDependencies": {
         "eslint": "^8.22.0",
@@ -3923,6 +3924,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.14.0.tgz",
+      "integrity": "sha512-TBzhheU15s+o54Cgk9qxuYcZMiqSm/SkvKnapoGHOF66kz0Y5aGjpzj5BT/vpBbn6rTPJ9tUYXQxuDWfsjiGMw=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
+      "integrity": "sha512-DHk3zFvsxrkcnurGvQlAcLuTDacAVN1JHKDgcba/gr2NFRE4HGwP1YeHIXMiGznkWR4AeS7X5vEblNn4QljuNA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=4.11.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
+      }
+    },
     "node_modules/tar": {
       "version": "6.1.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
@@ -7278,6 +7298,19 @@
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.14.0.tgz",
+      "integrity": "sha512-TBzhheU15s+o54Cgk9qxuYcZMiqSm/SkvKnapoGHOF66kz0Y5aGjpzj5BT/vpBbn6rTPJ9tUYXQxuDWfsjiGMw=="
+    },
+    "swagger-ui-express": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.5.0.tgz",
+      "integrity": "sha512-DHk3zFvsxrkcnurGvQlAcLuTDacAVN1JHKDgcba/gr2NFRE4HGwP1YeHIXMiGznkWR4AeS7X5vEblNn4QljuNA==",
+      "requires": {
+        "swagger-ui-dist": ">=4.11.0"
       }
     },
     "tar": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "jsonwebtoken": "^8.5.1",
     "morgan": "~1.9.1",
     "mysql2": "^2.2.3",
-    "sequelize": "^6.3.5"
+    "sequelize": "^6.3.5",
+    "swagger-ui-express": "^4.5.0"
   },
   "devDependencies": {
     "eslint": "^8.22.0",


### PR DESCRIPTION
Se implementa la documentación con swagger utilizando module.exports para enviar la configuración a swagger-ui-express y emplear archivos .js en lugar de .json, se deja construido un ejemplo completo del uso, con componentes, paths, protección de ruta y schemas
![image](https://user-images.githubusercontent.com/89424824/189548570-4c597592-1596-4ee9-a062-275702683a16.png)
