### PR TITLE
testimonials pagination

### DIFF
--- a/controllers/testimonialsController.js
+++ b/controllers/testimonialsController.js
@@ -1,5 +1,6 @@
 const { Testimonial } = require('../models');
 const { NotFound } = require('../utils/error');
+const ApiUtils = require('../utils/apiUtils')
 
 class TestimonialController {
   static async updateTestimonial(req, res) {
@@ -29,6 +30,33 @@ class TestimonialController {
     }
     return res.send(new NotFound());
   }
+  static async getAll(req, res) {
+    const baseUrl = await ApiUtils.getBaseUrl(req);
+    let { page } = req.query;
+
+    const options = {};
+    let pages = {};
+
+    if (page) {
+      page = parseInt(page, 10);
+      options.limit = 10;
+      options.offset = (page - 1) * 10;
+    }
+
+    let testimonials;
+    try {
+      testimonials = await Testimonial.findAndCountAll(options);
+    } catch (err) {
+      res.status(500).send({ msg: 'Internal Server error', error: err.message });
+    }
+
+    if (page) {
+      pages = await ApiUtils.getPagination(baseUrl, page, testimonials.count);
+    }
+
+    res.status(200).send({ msg: 'Lista de testimonios', ...pages, testimonials: testimonials.rows });
+  }
+
 }
 
 module.exports = TestimonialController;

--- a/routes/testimonials.js
+++ b/routes/testimonials.js
@@ -15,4 +15,6 @@ router.post(
 );
 router.put('/:id', RoleValidator.isAdmin, TestimonialController.updateTestimonial);
 router.delete('/:id', RoleValidator.isAdmin, TestimonialController.deleteTestimonial);
+router.get('/', TestimonialController.getAll);
+
 module.exports = router;

--- a/utils/apiUtils.js
+++ b/utils/apiUtils.js
@@ -4,7 +4,7 @@ class ApiUtils {
   }
   static async getPagination(baseUrl, page, total) {
     const nextPage = total / 10 > page ? `${baseUrl}?page=${page + 1}` : null;
-    const previousPage = page < 1 ? null : `${baseUrl}?page=${page - 1}`;
+    const previousPage = page < 2 ? null : `${baseUrl}?page=${page - 1}`;
     const pages = { nextPage, currentPage: page, previousPage };
 
     return pages;


### PR DESCRIPTION
Testimonials pagination + correción en ApiUtils. Al posicionarse en la page 1 la variable "previousPage" no es null y muestra la url con la query "?page=0". Al pasar "page < 2" ya la variable es null. El "<" funciona en realidad como un "=<" no se porqué.